### PR TITLE
feat: initial Ansible homelab infrastructure setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+inventories/homelab
+
+**/*.local.md
+
+.vscode/
+
+.ansible

--- a/README.md
+++ b/README.md
@@ -1,6 +1,27 @@
 # Ansible Homelab Infrastructure
 
-This repository contains Ansible playbooks and roles for managing a homelab infrastructure with a focus on Docker deployment, user management, filesystem synchronization, and NFS mount configuration.
+- [Ansible Homelab Infrastructure](#ansible-homelab-infrastructure)
+  - [Project Structure](#project-structure)
+  - [Available Roles](#available-roles)
+    - [filesystem\_sync](#filesystem_sync)
+    - [install\_docker](#install_docker)
+    - [ping\_hosts](#ping_hosts)
+    - [setup\_nfs\_mount](#setup_nfs_mount)
+    - [update\_system\_packages](#update_system_packages)
+    - [users\_and\_groups\_sync](#users_and_groups_sync)
+  - [Usage](#usage)
+    - [Running Playbooks](#running-playbooks)
+    - [Syntax Checking](#syntax-checking)
+    - [Linting](#linting)
+  - [Configuration](#configuration)
+    - [Inventory Structure](#inventory-structure)
+    - [Variable Naming Convention](#variable-naming-convention)
+  - [Requirements](#requirements)
+  - [Security Considerations](#security-considerations)
+  - [Contributing](#contributing)
+  - [License](#license)
+
+This repository contains Ansible playbooks and roles for managing my homelab infrastructure with user management, filesystem synchronization, and NFS mount configuration.
 
 ## Project Structure
 
@@ -30,29 +51,38 @@ ansible/
 ## Available Roles
 
 ### filesystem_sync
+
 Creates and synchronizes directories across hosts. Requires:
+
 - `filesystem_sync_target_directories`: List of directories to create
 - `filesystem_sync_target_directories_owner`: Owner for directories
 - `filesystem_sync_target_directories_group`: Group for directories
 
 ### install_docker
+
 Installs Docker and Docker Compose packages, ensures the Docker service is enabled and running.
 
 ### ping_hosts
+
 Simple connectivity test role that pings hosts and displays results.
 
 ### setup_nfs_mount
+
 Configures NFS mounts on target hosts. Supports both Debian and Arch Linux distributions. Requires:
+
 - `setup_nfs_mount_mounts`: List of mount configurations with source and target paths
 - `filesystem.nfs.server`: NFS server hostname/IP
 - `filesystem.nfs.fstype`: Filesystem type (e.g., nfs4)
 - `filesystem.nfs.options`: Mount options
 
 ### update_system_packages
+
 Updates system packages on target hosts (implementation not shown in current code).
 
 ### users_and_groups_sync
+
 Synchronizes users and groups across all hosts. Requires:
+
 - `acl.users`: List of users with their properties (name, uid, groups)
 - `acl.groups`: List of groups with their properties (name, gid)
 
@@ -93,6 +123,7 @@ ansible-lint playbooks/
 ### Inventory Structure
 
 The inventory follows a hierarchical structure with:
+
 - Host definitions in `hosts.yml`
 - Group variables in `group_vars/` directory
 - Variables cascade from `all.yml` to specific group files
@@ -100,6 +131,7 @@ The inventory follows a hierarchical structure with:
 ### Variable Naming Convention
 
 Variables use a namespace prefix to avoid conflicts:
+
 - `lab_` for general lab variables
 - `acl_` for access control list variables
 - `filesystem_` for filesystem-related variables

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ ansible/
 │       ├── group_vars/            # Group-specific variables
 │       │   ├── all.yml           # Variables for all hosts
 │       │   ├── cloud.yml         # Variables for cloud hosts
+│       │   ├── docker.yml        # Variables for Docker hosts
 │       │   └── onprem.yml        # Variables for on-premise hosts
 │       ├── hosts.yml             # Host definitions and groupings
 │       └── README.md             # Example inventory documentation
@@ -98,7 +99,11 @@ The inventory follows a hierarchical structure with:
 
 ### Variable Naming Convention
 
-Variables use a namespace prefix (e.g., `ex_` for example inventory, `gx_` for production) to avoid conflicts.
+Variables use a namespace prefix to avoid conflicts:
+- `lab_` for general lab variables
+- `acl_` for access control list variables
+- `filesystem_` for filesystem-related variables
+- Use your own prefix for custom variables
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,126 @@
-# ansible
+# Ansible Homelab Infrastructure
+
+This repository contains Ansible playbooks and roles for managing a homelab infrastructure with a focus on Docker deployment, user management, filesystem synchronization, and NFS mount configuration.
+
+## Project Structure
+
+```
+ansible/
+├── .gitignore                     # Git ignore file
+├── inventories/                   # Host inventories and group variables
+│   └── example/                   # Example inventory demonstrating structure
+│       ├── group_vars/            # Group-specific variables
+│       │   ├── all.yml           # Variables for all hosts
+│       │   ├── cloud.yml         # Variables for cloud hosts
+│       │   └── onprem.yml        # Variables for on-premise hosts
+│       ├── hosts.yml             # Host definitions and groupings
+│       └── README.md             # Example inventory documentation
+└── playbooks/                     # Ansible playbooks and roles
+    ├── docker.playbook.yml        # Main Docker deployment playbook
+    └── roles/                     # Reusable Ansible roles
+        ├── filesystem_sync/       # Creates and manages directories
+        ├── install_docker/        # Installs Docker and Docker Compose
+        ├── ping_hosts/           # Basic connectivity test
+        ├── setup_nfs_mount/      # Configures NFS mounts
+        ├── update_system_packages/# System package updates
+        └── users_and_groups_sync/ # User and group management
+```
+
+## Available Roles
+
+### filesystem_sync
+Creates and synchronizes directories across hosts. Requires:
+- `filesystem_sync_target_directories`: List of directories to create
+- `filesystem_sync_target_directories_owner`: Owner for directories
+- `filesystem_sync_target_directories_group`: Group for directories
+
+### install_docker
+Installs Docker and Docker Compose packages, ensures the Docker service is enabled and running.
+
+### ping_hosts
+Simple connectivity test role that pings hosts and displays results.
+
+### setup_nfs_mount
+Configures NFS mounts on target hosts. Supports both Debian and Arch Linux distributions. Requires:
+- `setup_nfs_mount_mounts`: List of mount configurations with source and target paths
+- `filesystem.nfs.server`: NFS server hostname/IP
+- `filesystem.nfs.fstype`: Filesystem type (e.g., nfs4)
+- `filesystem.nfs.options`: Mount options
+
+### update_system_packages
+Updates system packages on target hosts (implementation not shown in current code).
+
+### users_and_groups_sync
+Synchronizes users and groups across all hosts. Requires:
+- `acl.users`: List of users with their properties (name, uid, groups)
+- `acl.groups`: List of groups with their properties (name, gid)
+
+## Usage
+
+### Running Playbooks
+
+Execute playbooks against a specific inventory:
+
+```bash
+ansible-playbook -i inventories/example/hosts.yml playbooks/docker.playbook.yml
+```
+
+Target specific hosts or groups:
+
+```bash
+ansible-playbook -i inventories/example/hosts.yml playbooks/docker.playbook.yml -l cloud
+```
+
+### Syntax Checking
+
+Validate playbook syntax before running:
+
+```bash
+ansible-playbook --syntax-check -i inventories/example/hosts.yml playbooks/docker.playbook.yml
+```
+
+### Linting
+
+Check for best practices and common issues:
+
+```bash
+ansible-lint playbooks/
+```
+
+## Configuration
+
+### Inventory Structure
+
+The inventory follows a hierarchical structure with:
+- Host definitions in `hosts.yml`
+- Group variables in `group_vars/` directory
+- Variables cascade from `all.yml` to specific group files
+
+### Variable Naming Convention
+
+Variables use a namespace prefix (e.g., `ex_` for example inventory, `gx_` for production) to avoid conflicts.
+
+## Requirements
+
+- Python 3.11+
+- Ansible
+- ansible-lint (for linting)
+
+## Security Considerations
+
+- Use Ansible Vault for sensitive data
+- Store private keys securely
+- Follow principle of least privilege for user permissions
+- Keep inventory files with sensitive data out of version control
+
+## Contributing
+
+1. Create feature branches for changes
+2. Follow the established code style
+3. Update documentation as needed
+4. Run syntax checks and linting before committing
+5. Create pull requests for review
+
+## License
+
+[Specify your license here]

--- a/inventories/example/README.md
+++ b/inventories/example/README.md
@@ -1,29 +1,102 @@
-# Example Inventory
+# Example Ansible Inventory
 
-This is an example inventory structure that demonstrates:
-
-- How to organize hosts into logical groups
-- How to set variables at different levels (all hosts, group-specific)
-- How to define connection methods for different types of hosts
+This is an example inventory structure that demonstrates how to organize hosts and groups for an Ansible homelab environment.
 
 ## Structure
 
-- `hosts.yml` - Main inventory file defining hosts and groups
-- `group_vars/` - Group-specific variables
-  - `all.yml` - Variables applied to all hosts
-  - `cloud.yml` - Variables for cloud-hosted servers
-  - `onprem.yml` - Variables for on-premise servers
+```
+inventories/example/
+├── hosts.yml               # Main inventory file with host definitions
+├── group_vars/            # Variables specific to groups
+│   ├── all.yml           # Variables that apply to all hosts
+│   ├── cloud.yml         # Variables for cloud-hosted servers
+│   ├── docker.yml        # Variables for Docker hosts
+│   └── onprem.yml        # Variables for on-premise servers
+└── README.md             # This file
+```
+
+## hosts.yml
+
+The main inventory file organizes hosts into logical groups:
+
+- **cloud**: Cloud-hosted servers (VPS)
+- **docker**: Dedicated Docker container hosts
+- **raspberrypi**: Raspberry Pi nodes (RPi 4 and 5)
+- **servers**: On-premise physical or virtual servers
+- **laptop**: Development laptops
+- **workstation**: Development workstations
+- **homelab**: Custom grouping that includes specific children groups
+
+### Host Properties
+
+Each host can have:
+- `ansible_host`: The actual hostname or IP address to connect to
+- `host_tags`: Custom tags for categorization (e.g., `vps`, `docker`, `vm`, `rpi4`)
+
+## Group Variables
+
+### all.yml
+Contains variables that apply to all hosts:
+- ACL configurations (users and groups)
+- Filesystem paths and permissions
+- NFS and CIFS mount configurations
+- Default settings for the entire inventory
+
+### cloud.yml
+Specific to cloud-hosted servers:
+- SSH connection settings
+- Authentication method
+- User credentials
+
+### docker.yml
+Specific to Docker hosts:
+- Docker volume storage location
+
+### onprem.yml
+Specific to on-premise servers:
+- SSH connection settings
+- Authentication method
 
 ## Usage
 
-Run commands against this inventory with:
+1. Copy this example directory as a template for your own inventory:
+   ```bash
+   cp -r inventories/example inventories/mylab
+   ```
 
-```bash
-ansible-playbook -i inventories/example/hosts.yml playbooks/your-playbook.yml
-```
+2. Update the hosts and variables according to your environment:
+   - Modify hostnames and IP addresses in `hosts.yml`
+   - Adjust user credentials and paths in group variables
+   - Add or remove groups as needed
 
-To target a specific group:
+3. Test your inventory:
+   ```bash
+   ansible-inventory -i inventories/mylab/hosts.yml --list
+   ```
 
-```bash
-ansible-playbook -i inventories/example/hosts.yml playbooks/your-playbook.yml -l cloud
-```
+4. Run a playbook using this inventory:
+   ```bash
+   ansible-playbook -i inventories/mylab/hosts.yml playbooks/test.playbook.yml
+   ```
+
+## Best Practices
+
+- Use descriptive host names that indicate purpose or location
+- Group hosts logically based on their role or characteristics
+- Keep sensitive data in Ansible Vault (not shown in this example)
+- Use consistent naming conventions throughout
+- Document any custom variables or configurations
+- Test connectivity before running complex playbooks:
+  ```bash
+  ansible -i inventories/mylab/hosts.yml all -m ping
+  ```
+
+## Variable Precedence
+
+Variables are applied in the following order (from lowest to highest precedence):
+1. all.yml (applies to all hosts)
+2. Group-specific variables (e.g., cloud.yml, docker.yml)
+3. Host-specific variables (defined in hosts.yml)
+4. Command-line variables
+
+This means more specific variables override more general ones.

--- a/inventories/example/README.md
+++ b/inventories/example/README.md
@@ -1,0 +1,29 @@
+# Example Inventory
+
+This is an example inventory structure that demonstrates:
+
+- How to organize hosts into logical groups
+- How to set variables at different levels (all hosts, group-specific)
+- How to define connection methods for different types of hosts
+
+## Structure
+
+- `hosts.yml` - Main inventory file defining hosts and groups
+- `group_vars/` - Group-specific variables
+  - `all.yml` - Variables applied to all hosts
+  - `cloud.yml` - Variables for cloud-hosted servers
+  - `onprem.yml` - Variables for on-premise servers
+
+## Usage
+
+Run commands against this inventory with:
+
+```bash
+ansible-playbook -i inventories/example/hosts.yml playbooks/your-playbook.yml
+```
+
+To target a specific group:
+
+```bash
+ansible-playbook -i inventories/example/hosts.yml playbooks/your-playbook.yml -l cloud
+```

--- a/inventories/example/group_vars/all.yml
+++ b/inventories/example/group_vars/all.yml
@@ -1,0 +1,7 @@
+# Variables that apply to all groups and hosts
+example_debug: false
+
+# Prefix variables with the project namespace (ex_)
+ex_backup_enabled: true
+ex_monitoring_level: standard
+ex_alert_email: alerts@example.com

--- a/inventories/example/group_vars/all.yml
+++ b/inventories/example/group_vars/all.yml
@@ -1,7 +1,47 @@
 # Variables that apply to all groups and hosts
-example_debug: false
 
-# Prefix variables with the project namespace (ex_)
-ex_backup_enabled: true
-ex_monitoring_level: standard
-ex_alert_email: alerts@example.com
+# Debug mode setting
+lab_debug: false
+
+# Access Control List (ACL) configurations
+acl:
+  default_user: "labuser"
+  default_group: "labgroup"
+  # Define users and groups for the lab environment
+  users:
+  - name: "labuser"
+    uid: 1000
+    groups:
+    - "adm"
+    - "sudo"
+    - "docker"
+    - "kvm"
+    - "media"
+    - "labgroup"
+  groups:
+  - name: "media"
+    gid: 114
+  - name: "labgroup"
+    gid: 2000
+
+# Filesystem configuration
+filesystem:
+  root_folder: "/homelab"
+  storage_folder: "/storage"
+  # Docker volume storage location (for homelab hosts, not docker hosts)
+  docker_volume_folder: "/docker-storage"
+  mode: '0755'
+  owner: "{{ acl.default_user }}"
+  group: "{{ acl.default_group }}"
+
+  # NFS mount configuration
+  nfs:
+    server: "storage.local"
+    options: "_netdev,rw,rsize=1048576,wsize=1048576,vers=4.2,auto,users"
+    fstype: "nfs4"
+
+  # SMB/CIFS mount configuration
+  cifs:
+    server: "storage.local"
+    options: "vers=3.0,credentials=/etc/labcreds/.sharelogin,iocharset=utf8,file_mode=0777,dir_mode=0777,uid=1000,gid=1000,nofail"
+    fstype: "cifs"

--- a/inventories/example/group_vars/cloud.yml
+++ b/inventories/example/group_vars/cloud.yml
@@ -1,5 +1,4 @@
 # Variables specific to the 'cloud' group
-ansible_user: admin
+ansible_user: labuser
 ansible_become: true
 ansible_become_method: sudo
-ansible_ssh_private_key_file: ~/.ssh/cloud_key

--- a/inventories/example/group_vars/cloud.yml
+++ b/inventories/example/group_vars/cloud.yml
@@ -1,0 +1,5 @@
+# Variables specific to the 'cloud' group
+ansible_user: admin
+ansible_become: true
+ansible_become_method: sudo
+ansible_ssh_private_key_file: ~/.ssh/cloud_key

--- a/inventories/example/group_vars/docker.yml
+++ b/inventories/example/group_vars/docker.yml
@@ -1,0 +1,2 @@
+# Variables specific to the 'docker' group
+docker_volume_folder: /docker-storage

--- a/inventories/example/group_vars/onprem.yml
+++ b/inventories/example/group_vars/onprem.yml
@@ -1,0 +1,5 @@
+# Variables specific to the 'onprem' group
+ansible_user: localadmin
+ansible_become: true
+ansible_become_method: sudo
+ansible_connection: ssh

--- a/inventories/example/group_vars/onprem.yml
+++ b/inventories/example/group_vars/onprem.yml
@@ -1,5 +1,5 @@
-# Variables specific to the 'onprem' group
-ansible_user: localadmin
+# Variables specific to the 'onprem' group  
+ansible_user: labuser
 ansible_become: true
 ansible_become_method: sudo
 ansible_connection: ssh

--- a/inventories/example/hosts.yml
+++ b/inventories/example/hosts.yml
@@ -1,22 +1,90 @@
----
-# Example inventory file showing how to organize hosts and groups
+# vim: set ft=yaml:
+# vim: set ts=2 sw=2 et:
 
 all:
   children:
-    # Group containing cloud-hosted servers
+    # Group containing cloud-hosted servers (VPS)
     cloud:
       hosts:
-        webserver01:
-          ansible_host: webserver01.example.com
-        dbserver01:
-          ansible_host: dbserver01.example.com
+        cloud-vps-001:
+          ansible_host: cloud-vps-001.example.com
+          host_tags:
+          - vps
+          - remote
           
-    # Group containing on-premise physical servers
-    onprem:
+    # Group containing Docker hosts
+    docker:
       hosts:
-        appserver01:
-          ansible_host: appserver01.local
-        appserver02:
-          ansible_host: appserver02.local
-        appserver03:
-          ansible_host: appserver03.local
+        docker-node-001:
+          ansible_host: docker-node-001.local
+          host_tags:
+          - docker
+          - vm
+        docker-node-002:
+          ansible_host: docker-node-002.local
+          host_tags:
+          - docker
+          - vm
+          
+    # Group containing Raspberry Pi nodes
+    raspberrypi:
+      hosts:
+        rpi-node-100:
+          ansible_host: rpi-node-100.local
+          host_tags:
+          - rpi4
+        rpi-node-101:
+          ansible_host: rpi-node-101.local
+          host_tags:
+          - rpi4
+        rpi-node-500:
+          ansible_host: rpi-node-500.local
+          host_tags:
+          - rpi5
+          
+    # Group containing on-premise servers
+    servers:
+      hosts:
+        server-001:
+          ansible_host: server-001.local
+          host_tags:
+          - proxmox
+        server-002:
+          ansible_host: server-002.local
+          host_tags:
+          - proxmox
+        media-server:
+          ansible_host: media-server.local
+          host_tags:
+          - media-server
+        proxy-server:
+          ansible_host: proxy-server.local
+          host_tags:
+          - nginx-proxy-manager
+          - wireguard-server
+        k3s-node-001:
+          ansible_host: k3s-node-001.local
+          host_tags:
+          - vm
+        k3s-node-002:
+          ansible_host: k3s-node-002.local
+          host_tags:
+          - vm
+          
+    # Group containing laptops
+    laptop:
+      hosts:
+        dev-laptop:
+          ansible_host: laptop-wlan.local
+          
+    # Group containing workstations
+    workstation:
+      hosts:
+        dev-workstation:
+          ansible_host: dev-workstation.local
+
+# Example of a custom grouping based on role or location
+homelab:
+  children:
+    raspberrypi:
+    servers:

--- a/inventories/example/hosts.yml
+++ b/inventories/example/hosts.yml
@@ -1,0 +1,22 @@
+---
+# Example inventory file showing how to organize hosts and groups
+
+all:
+  children:
+    # Group containing cloud-hosted servers
+    cloud:
+      hosts:
+        webserver01:
+          ansible_host: webserver01.example.com
+        dbserver01:
+          ansible_host: dbserver01.example.com
+          
+    # Group containing on-premise physical servers
+    onprem:
+      hosts:
+        appserver01:
+          ansible_host: appserver01.local
+        appserver02:
+          ansible_host: appserver02.local
+        appserver03:
+          ansible_host: appserver03.local

--- a/playbooks/docker.playbook.yml
+++ b/playbooks/docker.playbook.yml
@@ -1,0 +1,27 @@
+- name: Add docker/docker-compose related packages and configuration
+  hosts: docker
+  gather_facts: true
+  become: true
+
+  roles:
+    - role: update_system_packages
+    - role: users_and_groups_sync
+    - role: filesystem_sync
+      vars:
+        filesystem_sync_target_directories:
+          - "{{ filesystem.root_folder }}"
+          - "{{ filesystem.storage_folder }}"
+        filesystem_sync_target_directories_owner: "{{ filesystem.owner | default(acl.default_user) }}"
+        filesystem_sync_target_directories_group: "{{ filesystem.group | default(acl.default_group) }}"
+    - role: filesystem_sync
+      vars:
+        filesystem_sync_target_directories:
+          - "{{ docker_volume_folder }}"
+        filesystem_sync_target_directories_owner: "{{ docker_user | default(acl.default_user) }}"
+        filesystem_sync_target_directories_group: "{{ docker_group | default(acl.default_group) }}"
+    - role: install_docker
+    - role: setup_nfs_mount
+      vars:
+        setup_nfs_mount_mounts:
+          - source: "{{ filesystem.root_folder }}"
+            target: "{{ filesystem.root_folder }}"

--- a/playbooks/roles/filesystem_sync/tasks/main.yml
+++ b/playbooks/roles/filesystem_sync/tasks/main.yml
@@ -1,0 +1,18 @@
+# This role ensure that directories are created and synchronized across all hosts in the homelab.
+#
+
+- name: Check if filesystem_sync_target_directories is defined
+  ansible.builtin.assert:
+    that:
+      - filesystem_sync_target_directories is defined
+    fail_msg: "The variable 'filesystem_sync_target_directories' must be defined."
+
+- name: Ensure directory directories exist
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: '0755'
+    owner: "{{ filesystem_sync_target_directories_owner | default(acl.default_user) }}"
+    group: "{{ filesystem_sync_target_directories_group | default(acl.default_group) }}"
+  loop: "{{ filesystem_sync_target_directories }}"
+  when: filesystem_sync_target_directories is defined

--- a/playbooks/roles/install_docker/tasks/main.yml
+++ b/playbooks/roles/install_docker/tasks/main.yml
@@ -1,0 +1,17 @@
+# Install docker and docker compose on the docker hosts.
+
+- name: Install docker and docker compose on the docker hosts
+  ansible.builtin.package:
+    name: "{{ item }}"
+    state: present
+  loop:
+    - docker.io
+    - docker-compose
+    - containerd
+    - containernetworking-plugins
+
+- name: Ensure docker service is enabled and started
+  ansible.builtin.systemd:
+    name: docker
+    enabled: true
+    state: started

--- a/playbooks/roles/ping_hosts/tasks/main.yml
+++ b/playbooks/roles/ping_hosts/tasks/main.yml
@@ -1,0 +1,8 @@
+- name: Ping host
+  ansible.builtin.ping:
+  delegate_to: localhost
+  register: ping_result
+
+- name: Display ping results
+  ansible.builtin.debug:
+    var: ping_result

--- a/playbooks/roles/setup_nfs_mount/tasks/main.yml
+++ b/playbooks/roles/setup_nfs_mount/tasks/main.yml
@@ -1,0 +1,38 @@
+# Setup NFS Share Mount
+
+- name: Gather OS-specific facts
+  ansible.builtin.setup:
+    filter: ansible_os_family
+
+- name: Install NFS packages (Debian)
+  ansible.builtin.package:
+    name: "nfs-common"
+    state: present
+  when: ansible_os_family == "Debian"
+
+- name: Install NFS packages (Arch)
+  ansible.builtin.package:
+    name: "nfs-utils"
+    state: present
+  when: ansible_os_family == "Archlinux"
+
+- name: Ensure NFS mount point exists
+  ansible.builtin.file:
+    path: "{{ item.target }}"
+    state: directory
+    mode: "{{ filesystem.mode | default('0755') }}"
+    owner: "{{ filesystem.owner | default(acl.default_user) }}"
+    group: "{{ filesystem.group | default(acl.default_group) }}"
+  loop: "{{ setup_nfs_mount_mounts }}"
+  when: setup_nfs_mount_mounts is defined and setup_nfs_mount_mounts | length > 0
+
+- name: Update NFS mount entries in /etc/fstab
+  ansible.posix.mount:
+    path: "{{ item.target }}"
+    src: "{{ filesystem.nfs.server }}:{{ item.source }}"
+    fstype: "{{ filesystem.nfs.fstype }}"
+    opts: "{{ filesystem.nfs.options }}"
+    state: mounted
+    boot: true
+  loop: "{{ setup_nfs_mount_mounts }}"
+  when: setup_nfs_mount_mounts is defined and setup_nfs_mount_mounts | length > 0

--- a/playbooks/roles/update_system_packages/tasks/main.yml
+++ b/playbooks/roles/update_system_packages/tasks/main.yml
@@ -1,0 +1,38 @@
+# This role updates system packages using the appropriate package manager for the OS family.
+
+# skip this role if host_tags contains 'proxmox'
+- name: Check if ansible_run_tags contains 'proxmox' or 'remote'
+  ansible.builtin.set_fact:
+    skip_update: "{{ 'proxmox' in host_tags or 'remote' in host_tags }}"
+  when: host_tags is defined and "'proxmox' in host_tags or 'remote' in host_tags"
+
+- name: Gather OS-specific facts
+  ansible.builtin.setup:
+    filter: ansible_os_family
+  when:
+    - skip_update is defined
+    - skip_update is false
+
+- name: Update packages (APT)
+  ansible.builtin.apt:
+    update_cache: true
+    upgrade: dist
+  become: true
+  when:
+    - ansible_os_family is defined
+    - ansible_os_family in ["Debian", "Ubuntu"]
+    - skip_update is defined
+    - skip_update is false
+  tags: update
+
+- name: Update packages (Pacman)
+  community.general.pacman:
+    update_cache: true
+    upgrade: true
+  become: true
+  when:
+    - ansible_os_family is defined
+    - ansible_os_family == "Archlinux"
+    - skip_update is defined
+    - skip_update is false
+  tags: update

--- a/playbooks/roles/users_and_groups_sync/tasks/main.yml
+++ b/playbooks/roles/users_and_groups_sync/tasks/main.yml
@@ -1,0 +1,43 @@
+# This role ensure that users and groups are synchronized across all hosts in the homelab.
+
+- name: Check if user exists
+  ansible.builtin.user:
+    name: "{{ item.name }}"
+    uid: "{{ item.uid | default(omit) }}"
+    state: present
+  loop: "{{ acl.users }}"
+  when: acl.users is defined and item.name is defined
+  register: user_check
+
+- name: Debug user check results
+  ansible.builtin.debug:
+    msg: "User check results: {{ user_check }}"
+
+- name: Ensure user groups are present
+  ansible.builtin.group:
+    name: "{{ item.name }}"
+    gid: "{{ item.gid | default(omit) }}"
+    state: present
+  loop: "{{ acl.groups }}"
+  when: acl.groups is defined and item.name is defined
+  register: group_check
+
+- name: Debug group check results
+  ansible.builtin.debug:
+    msg: "Group check results: {{ group_check }}"
+
+- name: Ensure users are in their respective groups
+  ansible.builtin.user:
+    name: "{{ item.name }}"
+    groups: "{{ item.groups | join(',') }}"
+    append: true
+  loop: "{{ acl.users }}"
+  when:
+    - acl.users is defined
+    - item.groups is defined
+    - item.name is defined
+  register: user_group_check
+
+- name: Debug user group check results
+  ansible.builtin.debug:
+    msg: "User group check results: {{ user_group_check }}"


### PR DESCRIPTION
## Summary
- Add comprehensive Ansible infrastructure for homelab management
- Include playbooks and roles for Docker, NFS, user sync, and system maintenance
- Provide detailed example inventory with anonymized homelab configuration

## Test plan
- [X] Test playbook syntax with `ansible-playbook --syntax-check`
- [X] Run ansible-lint on all playbooks
- [X] Test connectivity with ping_hosts role